### PR TITLE
Workaround for Ansible bug #29201

### DIFF
--- a/tasks/volume-present.yaml
+++ b/tasks/volume-present.yaml
@@ -5,6 +5,7 @@
     size: "{{ item[1].size | human_to_bytes }}B"
     opts: "{{ capra_lvm_filesystem_lvcreate_options }}"
     state: present
+    shrink: no
   with_indexed_items: "{{ capra_lvm_filesystem_specs }}"
 
 - name: Create filesystem


### PR DESCRIPTION
This works around a [bug in lvol](https://github.com/ansible/ansible/issues/29201) that seems to also affect perfectly round numbers in some cases. It wanted to shrink 20G to 20G and aborted when it couldn't.

Setting `shrink: no` on lvol is the workaround and should be safe since we don't shrink things anyway.